### PR TITLE
Verbose

### DIFF
--- a/tests/test_FrameCompare.py
+++ b/tests/test_FrameCompare.py
@@ -20,7 +20,7 @@ def frame2():
 def sample_fc(frame1, frame2):
     return FrameCompare(frame1, frame2)
 
-def test_fc(sample_fc):
+def test_frame_compare(sample_fc):
     expected_df = pd.DataFrame({'value': 1.01,
                                 'uncertainty': 0.036167,
                                 'uncertainty [%]': 3.580875,

--- a/tests/test_NormalizedFissionFragmentSpectrum.py
+++ b/tests/test_NormalizedFissionFragmentSpectrum.py
@@ -20,7 +20,7 @@ def sample_spectrum_data():
 def sample_integral_data():
     data = {
         "channel": [ 6.,  8., 10., 12., 14., 16., 18., 20., 22., 24.],
-        "value": [60, 80, 88, 87, 87, 88, 86, 85, 82, 78],
+        "value":   [60,  80,  88,  87,  87,  88,  86,  85,  82,  78],
         "uncertainty": [.1, .2, .3, .4, .5, .6, .7, .8, .9, .1]
     }
     return pd.DataFrame(data)
@@ -74,6 +74,16 @@ def test_time_normalization(nffs):
 def test_power_normalization(nffs):
     pd.testing.assert_frame_equal(nffs._power_normalization,
                                   _make_df(.01, 0.00031622776601683794))
+
+def test_get_verbose(nffs):
+    expected_df = pd.DataFrame({'FFS': 879.0999999999999, 'VAR_FFS': 879.0999999999999,
+                                'EM': 87, 'VAR_EM': .5 **2,
+                                'PM': 1 / .01, 'VAR_PM': 0.00031622776601683794 **2 / .01 **4,
+                                't': 1 / .1, 'VAR_t': 0}, index=['value'])
+    pd.testing.assert_frame_equal(expected_df,
+                                   nffs._get_verbose(nffs.plateau(),
+                                                     nffs._time_normalization,
+                                                     nffs._power_normalization))
 
 def test_per_unit_mass(nffs):
     expected_df = pd.DataFrame({

--- a/tests/test_SpectralIndex.py
+++ b/tests/test_SpectralIndex.py
@@ -85,6 +85,29 @@ def synthetic_one_g_xs_data():
 def test_deposit_ids(si):
     assert si.deposit_ids == ['D1', 'D2']
 
+def test_get_verbose(si):
+    expected_df = pd.DataFrame({'FFS_n': 8.79100000e+02,
+                                'VAR_FFS_n': 8.79100000e+02,
+                                'EM_n': 87,
+                                'VAR_EM_n': 2.50000000e-01,
+                                'PM_n': 1.00000000e+02,
+                                'VAR_PM_n': 1.00000000e+01,
+                                't_n': 10.,
+                                'VAR_t_n': 0,
+                                'FFS_d': 8.79100000e+02,
+                                'VAR_FFS_d': 8.79100000e+02,
+                                'EM_d': 87,
+                                'VAR_EM_d': 2.50000000e-01,
+                                'PM_d': 1.00000000e+02,
+                                'VAR_PM_d': 1.00000000e+01,
+                                't_d': 10.,
+                                'VAR_t_d': 0,
+                                '1GXS': 0,
+                                'VAR_1GXS': None}, index=['value'])
+    pd.testing.assert_frame_equal(expected_df, si._get_verbose(si.numerator.process(verbose=True),
+                                                               si.denominator.process(verbose=True),
+                                                               None))
+
 def test_process(si):
     expected_df = pd.DataFrame({'value': 1.,
                                 'uncertainty': 0.06588712284729072,
@@ -96,7 +119,7 @@ def test_process(si):
                                 'VAR_FRAC_EM_d': 0.000033,
                                 'VAR_FRAC_PM_d': 0.001000,
                                 'VAR_FRAC_1GXS': 0.}, index= ['value'])
-    pd.testing.assert_frame_equal(si.process(), expected_df, check_exact=False, atol=0.00001)
+    pd.testing.assert_frame_equal(expected_df, si.process(), check_exact=False, atol=0.00001)
 
 def test_compute_correction(si, synthetic_one_g_xs_data):
     w1, uw1, w2, uw2, wd, uwd = .1, .01, .2, .02, .7, .07


### PR DESCRIPTION
`_get_verbose` methods added to `NormalizedFissionFragmentSpectrum(_Experimental)` and `SpectralIndex(_Experimental)`.
The `process()` methods can now be called with `verbose=True` to get more information on the paramters values used in the equations as well as on their uncertainties.
This also enables external uncertainty calculations accounting for correlations among the variables used for the calculation of the experimental results.